### PR TITLE
support enum path in statement evaluation

### DIFF
--- a/src/main/java/org/jpasecurity/persistence/EntityManagerEvaluator.java
+++ b/src/main/java/org/jpasecurity/persistence/EntityManagerEvaluator.java
@@ -134,6 +134,9 @@ public class EntityManagerEvaluator extends AbstractSubselectEvaluator {
     }
 
     private Object getPathValue(Path path, Map<Alias, Object> aliases) {
+        if (path.isEnumValue()) {
+            return path.getEnumValue();
+        }
         Alias alias = path.getRootAlias();
         Object aliasValue = aliases.get(alias);
         if (!path.hasSubpath()) {


### PR DESCRIPTION
This commit prevents that an enum value will be treated as a path during a subselect evaluation.