### PR TITLE
Postpone access right checks

### DIFF
--- a/src/main/java/org/jpasecurity/AccessType.java
+++ b/src/main/java/org/jpasecurity/AccessType.java
@@ -22,4 +22,8 @@ public enum AccessType {
 
     CREATE, READ, UPDATE, DELETE;
     public static final AccessType[] ALL = {CREATE, READ, UPDATE, DELETE};
+
+    public boolean isWriteAccess() {
+        return !this.equals(READ);
+    }
 }

--- a/src/main/java/org/jpasecurity/persistence/DefaultSecureEntityManager.java
+++ b/src/main/java/org/jpasecurity/persistence/DefaultSecureEntityManager.java
@@ -389,7 +389,6 @@ public class DefaultSecureEntityManager extends DelegatingEntityManager
         getTransactionSynchronizationRegistry().registerInterposedSynchronization(new Synchronization() {
             @Override
             public void beforeCompletion() {
-                // nothing to do
                 accessManager.checkNow();
             }
             @Override

--- a/src/main/java/org/jpasecurity/persistence/DefaultSecureEntityManager.java
+++ b/src/main/java/org/jpasecurity/persistence/DefaultSecureEntityManager.java
@@ -385,10 +385,12 @@ public class DefaultSecureEntityManager extends DelegatingEntityManager
     }
 
     private void unregisterAccessManagerAfterTransaction() {
+        accessManager.setJtaTransactionActive();
         getTransactionSynchronizationRegistry().registerInterposedSynchronization(new Synchronization() {
             @Override
             public void beforeCompletion() {
                 // nothing to do
+                accessManager.checkNow();
             }
             @Override
             public void afterCompletion(int status) {

--- a/src/test/java/org/jpasecurity/model/MethodAccessTestBean.java
+++ b/src/test/java/org/jpasecurity/model/MethodAccessTestBean.java
@@ -41,7 +41,6 @@ public class MethodAccessTestBean {
 
     private int identifier;
     private String beanName;
-    private boolean setNameCalled;
     private MethodAccessTestBean parentBean;
     private List<MethodAccessTestBean> childBeans = new ArrayList<MethodAccessTestBean>();
     private Map<MethodAccessTestBean, MethodAccessTestBean> map
@@ -78,12 +77,7 @@ public class MethodAccessTestBean {
     }
 
     public void setName(String name) {
-        setNameCalled = true;
         beanName = name;
-    }
-
-    public boolean wasSetNameCalled() {
-        return setNameCalled;
     }
 
     @ManyToOne

--- a/src/test/java/org/jpasecurity/persistence/SubclassingTest.java
+++ b/src/test/java/org/jpasecurity/persistence/SubclassingTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 public class SubclassingTest {
 
     private static final String USER = "user";
-    private static final String USER_READ = "user_read";
+    private static final String USER_CRITERIA = "user_criteria";
 
     private EntityManagerFactory factory;
 
@@ -68,9 +68,9 @@ public class SubclassingTest {
         superclassReferencingBean = new SuperclassReferencingBean(subclass);
         entityManager.persist(superclassReferencingBean);
 
-        TestSecurityContext.authenticate(USER_READ);
-        TestBeanSubclass readTestBeanSubclass = new TestBeanSubclass(USER_READ);
-        entityManager.persist(readTestBeanSubclass);
+        TestSecurityContext.authenticate(USER_CRITERIA);
+        TestBeanSubclass criteriaTestBeanSubclass = new TestBeanSubclass(USER_CRITERIA);
+        entityManager.persist(criteriaTestBeanSubclass);
 
         entityManager.getTransaction().commit();
         entityManager.close();
@@ -89,7 +89,7 @@ public class SubclassingTest {
         assertEquals(1, entityManager.createQuery("SELECT bean FROM TestBean bean").getResultList().size());
         TestSecurityContext.authenticate(USER);
         assertEquals(2, entityManager.createQuery("SELECT bean FROM TestBean bean").getResultList().size());
-        TestSecurityContext.authenticate(USER_READ);
+        TestSecurityContext.authenticate(USER_CRITERIA);
         assertEquals(2, entityManager.createQuery("SELECT bean FROM TestBean bean").getResultList().size());
         entityManager.getTransaction().commit();
         entityManager.close();
@@ -118,10 +118,10 @@ public class SubclassingTest {
     }
 
     @Test
-    public void accessRulesOnSubclassesWithRead() {
+    public void accessRulesOnSubclassesWithCriteria() {
         EntityManager entityManager = factory.createEntityManager();
         entityManager.getTransaction().begin();
-        TestSecurityContext.authenticate(USER_READ);
+        TestSecurityContext.authenticate(USER_CRITERIA);
 
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         CriteriaQuery<TestBean> query = criteriaBuilder.createQuery(TestBean.class);

--- a/src/test/java/org/jpasecurity/persistence/security/CriteriaVisitorTest.java
+++ b/src/test/java/org/jpasecurity/persistence/security/CriteriaVisitorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -98,7 +99,8 @@ public class CriteriaVisitorTest {
         from.alias("testBean");
         query.where(from.get("parent").isNull());
 
-        accessRule.getWhereClause().visit(criteriaVisitor, new CriteriaHolder(query));
+        Map<String, Object> emptyParameterMap = Collections.emptyMap();
+        accessRule.getWhereClause().visit(criteriaVisitor, new CriteriaHolder(query, emptyParameterMap));
         List<TestBean> result = entityManager.createQuery(query).getResultList();
         assertEquals(1, result.size());
         assertEquals(1, result.iterator().next().getId());


### PR DESCRIPTION
Content:
- Postpone access right checks during JTA transaction to be executed on "beforeCommit". This should prevent Read during Update (Fix for ConcurrentModification and Shared References).
- Added unit test for enum path during evaluation of a subselect statement.
- Fix test after criteria parameter resolution fix.
- Add some minor test code refactoring.
